### PR TITLE
#184752095 Admin should be able to disable an account 

### DIFF
--- a/src/controllers/disEnableUser.js
+++ b/src/controllers/disEnableUser.js
@@ -1,0 +1,83 @@
+import db from '../../database/models';
+import {
+  sendEmail,
+  enableUserMessageTemplate,
+  disableUserMessageTemplate,
+} from '../utils/emails.js';
+
+const { user: User } = db;
+
+class dis_enableController {
+  static async disableUser({ params }, res) {
+    try {
+      const user = await User.findOne({ where: { id: params.id } });
+
+      if (!user) {
+        return res
+          .status(404)
+          .json({ error: 'Account to be disabled not found!' });
+      }
+
+      await User.update(
+        { isActive: false },
+        {
+          where: { id: params.id },
+          returning: true,
+          plain: true,
+        }
+      );
+
+      await sendEmail(
+        user.email,
+        user.name,
+        `Your SMITH-t-COMMERCE account was disabled`,
+        res,
+        disableUserMessageTemplate,
+        'disabled'
+      );
+
+      return res.status(200).json({
+        message: `Account was successfully disabled`,
+      });
+    } catch (e) {
+      return res.status(500).json({ error: e.message });
+    }
+  }
+
+  static async enableUser({ params }, res) {
+    try {
+      const user = await User.findOne({ where: { id: params.id } });
+
+      if (!user) {
+        return res
+          .status(404)
+          .json({ error: 'Account to be enabled not found!' });
+      }
+
+      const enabledUser = await User.update(
+        { isActive: true },
+        {
+          where: { id: params.id },
+          returning: true,
+        }
+      );
+
+      await sendEmail(
+        user.email,
+        user.name,
+        `Your SMITH-t-COMMERCE account was enabled`,
+        res,
+        enableUserMessageTemplate
+      );
+
+      return res.status(200).json({
+        message: `Account which belongs to ${user.name} was successfully enabled`,
+        enabledUser,
+      });
+    } catch (e) {
+      return res.status(500).json({ error: e.message });
+    }
+  }
+}
+
+export default dis_enableController;

--- a/src/docs/Admin/disableUser.js
+++ b/src/docs/Admin/disableUser.js
@@ -1,0 +1,75 @@
+const disableUser = {
+  tags: ['Admin'],
+  description: 'Disable User',
+  operationId: 'disableUser',
+
+  // parameters:
+
+  parameters: [
+    {
+      name: 'id',
+      in: 'path',
+      schema: {
+        $ref: '#/components/schemas/id',
+      },
+      required: true,
+      description: 'ID of the user to be disabled',
+    },
+  ],
+
+  // request body
+
+  requestBody: {},
+
+  responses: {
+    // success
+    200: {
+      desciption: 'Disable user successful',
+      content: {
+        'application/json': {
+          schema: {
+            message: 'Account was successfully disabled',
+          },
+        },
+      },
+    },
+
+    // not found
+    404: {
+      description: 'Failed to disable user',
+      content: {
+        'application/json': {
+          schema: {
+            message: 'User not found',
+          },
+        },
+      },
+    },
+
+    // unauthorized
+    401: {
+      desciption: 'Unauthorized to perform the action',
+      content: {
+        'application/json': {
+          schema: {
+            message: 'Login first to perform this action',
+          },
+        },
+      },
+    },
+
+    // server error
+    500: {
+      description: 'Internal server error',
+      content: {
+        'application/json': {
+          schema: {
+            message: 'Server error',
+          },
+        },
+      },
+    },
+  },
+};
+
+export default disableUser;

--- a/src/docs/Admin/enableUser.js
+++ b/src/docs/Admin/enableUser.js
@@ -1,0 +1,75 @@
+const enableUser = {
+  tags: ['Admin'],
+  description: 'enable User',
+  operationId: 'enableUser',
+
+  // paramers
+  parameters: [
+    {
+      name: 'id',
+      in: 'path',
+      schema: {
+        $ref: '#/components/schemas/id',
+      },
+      required: true,
+      description: 'ID to be disabled',
+    },
+  ],
+
+  // request body
+  requestBody: {},
+
+  // responses
+
+  responses: {
+    // ok
+    200: {
+      description: 'enable user successfully',
+      content: {
+        'application/json': {
+          schema: {
+           message: 'User successfully enabled',
+          },
+        },
+      },
+    },
+
+    // user not found
+    404: {
+      description: 'user not found',
+      content: {
+        'application/json': {
+          schema: {
+            message: 'User not found',
+          },
+        },
+      },
+    },
+
+    // unauthorized
+    401: {
+      description: 'Unauthorized to perform the action',
+      content: {
+        'application/json': {
+          schema: {
+            message: 'Login first to perform this action',
+          },
+        },
+      },
+    },
+
+    // server error
+    500: {
+      description: 'server error happened',
+      content: {
+        'application/json': {
+          schema: {
+            message: 'Server error',
+          },
+        },
+      },
+    },
+  },
+};
+
+export default enableUser;

--- a/src/docs/paths.js
+++ b/src/docs/paths.js
@@ -8,6 +8,8 @@ import addPayment from './Payment/createPayment.js';
 import createProduct from './Product/addProduct.js';
 import getProducts from './Product/getProducts.js';
 import updatedUser from './User/updateUser.js';
+import enableUser from './Admin/enableUser.js';
+import disableUser from './Admin/disableUser.js';
 
 const paths = {
   // REQUEST RESET PASSWORD
@@ -59,6 +61,14 @@ const paths = {
   // UPDATE USER
   '/users/{id}': {
     put: updatedUser,
+  },
+
+  // ENABLE AND DISABLE USER
+  '/users/enable/{id}': {
+    put: enableUser,
+  },
+  '/users/disable/{id}': {
+    put: disableUser,
   },
 };
 

--- a/src/docs/tags.js
+++ b/src/docs/tags.js
@@ -13,6 +13,10 @@ const tags = [
     name: 'Order',
     description: 'API for Orders in the E-Commerce app',
   },
+  {
+    name: 'Admin',
+    description: 'API for things only admin is allowed to access',
+  },
 ];
 
 export default tags;

--- a/src/middlewares/ensureIsEnabled.js
+++ b/src/middlewares/ensureIsEnabled.js
@@ -1,0 +1,23 @@
+import db from '../../database/models';
+
+const { user: User } = db;
+
+export default async (req, res, next) => {
+  const { email } = req.body;
+
+  try {
+    const findUser = await User.findOne({ where: { email } });
+    if (!findUser) {
+      return res
+        .status(404)
+        .send({ message: 'Account does not exist. Please Signup!' });
+    }
+    if (findUser.isActive === false) {
+      return res.status(401).send({ message: 'This Account is disabled' });
+    }
+
+    next();
+  } catch (e) {
+    return res.status(500).send({ message: e.message });
+  }
+};

--- a/src/routes/userRoute.js
+++ b/src/routes/userRoute.js
@@ -4,14 +4,21 @@ import loginController from '../controllers/loginController.js';
 import newsletterSubscribe from '../controllers/newsletterController.js';
 import userController from '../controllers/userController.js';
 import checkIsLoggedIn from '../middlewares/checkIsLoggedIn.js';
+import dis_enableController from '../controllers/disEnableUser.js';
+import ensureIsAdmin from '../middlewares/verifyIsAdmin.js';
+import ensureIsEnabled from '../middlewares/ensureIsEnabled.js';
 
 const router = express.Router();
 
 // REGISTER NEW USER ROUTE
 router.post('/signup', registerUser);
 
+// enable and disable user
+router.put('/disable/:id', ensureIsAdmin, dis_enableController.disableUser);
+router.put('/enable/:id', ensureIsAdmin, dis_enableController.enableUser);
+
 // LOGIN USER ROUTE
-router.post('/login', loginController.userLogin);
+router.post('/login', ensureIsEnabled, loginController.userLogin);
 
 // TWO FACTOR AUTHENTICATION
 router.get('/login/:token', loginController.twoFAController);

--- a/src/test/disable.test.js
+++ b/src/test/disable.test.js
@@ -1,0 +1,111 @@
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+import app from '../server.js';
+
+chai.should();
+chai.use(chaiHttp);
+const { expect } = chai;
+
+
+const admin = {
+    "email": "gabs0@gmail.com",
+    "password": "@Gaby12345"
+}
+
+const regularUser = {
+    "email": "gabs2@gmail.com",
+    "password": "@Gaby12345"
+}
+
+
+const regularUserId = 10
+const unkownUserId = 1067
+
+// TOKENS
+let adminCookie = '', regularCookie = '', adminToken = '', regularToken = '';
+
+
+describe('Login test', () => {
+    describe('Admin login', () => {
+      it('should return admin token', (done) => {
+        chai.request(app)
+          .post('/api/users/login')
+          .send(admin)
+          .end((err, res) => {
+            expect(res).to.have.status(200);
+            adminCookie = res.header['set-cookie'][0];
+            adminToken = res.body.Authorization;
+            console.log(adminCookie);
+            done();
+          });
+      });
+    });
+
+
+
+    describe('Regular user login', () => {
+        it('should return a regular token', (done) => {
+            chai.request(app)
+            .post('/api/users/login')
+            .send(regularUser)
+            .end((err, res) => {
+                expect(res).to.have.status(202);
+                regularCookie = res.header['set-cookie'][0];
+                regularToken = res.body.Authorization;
+                console.log(regularCookie);
+                done();
+            })
+        })
+    })
+});
+
+
+describe('Disable user', () => {
+    describe('User is enabled', () => {
+        it('Should disable a user', (done) => {
+            chai.request(app)
+            .put(`/api/users/disable/${regularUserId}`)
+            .set('cookie', adminCookie)
+            .end((err, res) => {
+                expect(res).to.have.status(200);
+                done();
+            })
+        })
+    });
+    describe('User is not found', () => {
+        it('Should return an error 404', (done) => {
+            chai.request(app)
+            .put(`/api/users/disable/${unkownUserId}`)
+            .set('cookie', adminCookie)
+            .end((err, res) => {
+                expect(res).to.have.status(404);
+                done();
+            })
+        })
+    })
+});
+
+describe('Enable user', () => {
+    describe('User not found', () => {
+        it('Should return error 404', (done) => {
+            chai.request(app)
+            .put(`/api/users/enable/${unkownUserId}`)
+            .set('cookie', adminCookie)
+            .end((err, res) => {
+                expect(res).to.have.status(404);
+                done();
+            })
+        })
+    });
+    describe('User is disabled', () => {
+        it('Should enable a user', (done) => {
+            chai.request(app)
+            .put(`/api/users/enable/${regularUserId}`)
+            .set('cookie', adminCookie)
+            .end((err, res) => {
+                expect(res).to.have.status(200);
+                done();
+            })
+        })
+    })
+})

--- a/src/utils/emails.js
+++ b/src/utils/emails.js
@@ -21,26 +21,18 @@ sgMail.setApiKey(process.env.SENDGRID_API_KEY);
 // REGISTER MESSAGE TEMPLATE
 const registerMessageTemplate = (name) => `
 Dear ${name},
-
 You have successfully registered on our platform. We are glad to have you on board.
-
 Below is the link to our platform. You can login with your email and password.
-
 ${host}/users/login
-
 Thank you for using our service.
 `;
 
 /* RESET PASSWORD MESSAGE TEMPLATE */
 const resetPasswordMessageTemplate = (name, token) => `
 Dear ${name},
-
 You have requested to reset your password. Please click on the link below to reset your password.
-
 ${host}/api/users/reset-password/${token}
-
 If you did not request for a password reset, please contact our support team.
-
 Thank you.
 `;
 
@@ -48,13 +40,9 @@ Thank you.
 
 const newsletterSubscriptionMessageTemplate = (name, token) => `
 Dear ${name},
-
 You have registered for our newsletter. To make sure it is you, please click on the link below to confirm your subscription.
-
 ${host}/api/users/confirm-newsletter/${token}
-
 If you did not request for a newsletter subscription, kindly ignore this email.
-
 Thank you.
 `;
 
@@ -62,13 +50,30 @@ Thank you.
 
 const twoFAMessageTemplate = (name, token) => `
 Dear ${name},
-
 You have requested to enable two factor authentication on your account. Please click on the link below to confirm your request.
-
 ${host}/api/users/login/${token}
-
 If you did not request for two factor authentication, please contact our support team.
+Thank you.
+`;
 
+/* SENDGRID EMAIL */
+// disable user MESSAGE TEMPLATE
+const disableUserMessageTemplate = (name) => `
+Dear ${name},
+We are sorry to inform you that your account has been temporarily disabled. This may
+be cause by improper conduct or other illegal transactions performed under your name.
+If uou believe that this is a mistake, kindly reach out to the site admin.
+Thank you.
+`;
+
+// disable user MESSAGE TEMPLATE
+const enableUserMessageTemplate = (name) => `
+Dear ${name},
+We are happy to inform you that your account has been enabled again. Make sure to
+abide with proper conduct or avoid illegal transactions performed under your account name.
+If uou believe that this is a mistake, kindly ignore this message.
+Follow this link to know mow:
+https://smithT/linkToContactUs
 Thank you.
 `;
 
@@ -121,6 +126,8 @@ export {
     registerMessageTemplate,
     resetPasswordMessageTemplate,
     newsletterSubscriptionMessageTemplate,
+    enableUserMessageTemplate,
+    disableUserMessageTemplate,
     twoFAMessageTemplate,
     nodeMail
 };


### PR DESCRIPTION
## What does this PR do?
This PR gives authority to the admin to enable or disable an account. The disabled or enabled account owner is informed by email.

## Description of Task to be completed?

GIVEN admin and multiple users exists on the sytem
WHEN a user is suspected or proved to have violated the terms of service of the application
THEN admin is able to trigger an action to block usage of a particular account and an email sent to the user with reasons from the block.

## How should this be manually tested?

-Clone the repository using `git clone` link
-Install node packages that the application depends on: `npm install`
-Create a `.env` file in the root directory and add all environment variables required to run the application. The required variables are listed in the `.env.example`  file available in root directory of the application.
-Start the application development server: `npm run dev`
-Test the user registration endpoint available on this address: `https://localhost:{PORT}/api/user/disable/{id}` to disable the user or:  `https://localhost:{PORT}/api/user/enable/{id}` to enable the user again, PORT being a local port that the application is running on.
-When the user is disabled, he cannot login

## Any background context you want to provide?
* Admin is able to disable the account
* Only the admin is able to disable the account
* When the user tries to disable the account he get the error of unauthorized -a disabled or enabled user is sent an email


## What are the relevant pivotal tracker/Trello stories?

  - [#184752095](https://www.pivotaltracker.com/story/show/184752095)
